### PR TITLE
サービスアカウント管理

### DIFF
--- a/platform_root/platform_api/controllers/users_service_controller.py
+++ b/platform_root/platform_api/controllers/users_service_controller.py
@@ -310,6 +310,7 @@ def user_get(organization_id, user_id):
         "preferred_username": user.get("username", ""),
         "name": common.get_username(user.get("firstName"), user.get("lastName"), user.get("username")),
         "affiliation": user.get("attributes", {}).get("affiliation", [""])[0],
+        "service_account_user_type": user.get("attributes", {}).get("service_account_user_type", [None])[0],
         "description": user.get("attributes", {}).get("description", [""])[0],
         "enabled": user.get("enabled", False),
         "create_timestamp": common.keycloak_timestamp_to_str(user.get("createdTimestamp")),

--- a/platform_root/platform_api/tests/test_user_service_controller.py
+++ b/platform_root/platform_api/tests/test_user_service_controller.py
@@ -80,6 +80,7 @@ def test_user_api(connexion_client):
         assert posted_user["lastName"] == post_user["lastName"]
         assert posted_user["email"] == post_user["email"]
         assert posted_user["affiliation"] == post_user["affiliation"]
+        assert posted_user["service_account_user_type"] is None
         assert posted_user["description"] == post_user["description"]
         assert posted_user["enabled"] == post_user["enabled"]
 
@@ -106,6 +107,7 @@ def test_user_api(connexion_client):
         assert puted_user["lastName"] == put_user["lastName"]
         assert puted_user["email"] == put_user["email"]
         assert puted_user["affiliation"] == put_user["affiliation"]
+        assert posted_user["service_account_user_type"] is None
         assert puted_user["description"] == put_user["description"]
         assert puted_user["enabled"] == put_user["enabled"]
 
@@ -475,6 +477,7 @@ def test_user_get(connexion_client):
         assert posted_user["lastName"] == post_user["lastName"]
         assert posted_user["email"] == post_user["email"]
         assert posted_user["affiliation"] == post_user["affiliation"]
+        assert posted_user["service_account_user_type"] is None
         assert posted_user["description"] == post_user["description"]
         assert posted_user["enabled"] == post_user["enabled"]
 

--- a/platform_root/platform_web/contents/platform-commons/js/service_account_user_list.js
+++ b/platform_root/platform_web/contents/platform-commons/js/service_account_user_list.js
@@ -152,7 +152,7 @@ $(function(){
                     .replace(/\${username}/g, fn.cv(user.username,'',true))
                     .replace(/\${serviceAccountUserType}/g, fn.cv(service_account_user_type_display,'',true))
                     .replace(/\${description}/g, fn.cv(user.description,'',true))
-                    .replace(/\${tokenExpiration}/g, fn.date(new Date(user.token_latest_expire_date),'yyyy/MM/dd HH:mm:ss'))
+                    .replace(/\${tokenExpiration}/g, fn.date(user.token_latest_expire_date,'yyyy/MM/dd HH:mm:ss'))
 
                 const $row = $("#service_account_users_list tbody").append(row_html).find(".datarow:last-child");
 


### PR DESCRIPTION
ユーザー取得APIに「service_account_user_type」の取得を追加
サービスアカウントユーザー一覧でrefresh tokenがない場合、有効期限を空欄にする